### PR TITLE
Fix parameter types names

### DIFF
--- a/src/main/java/de/retest/ui/descriptors/DefaultAttribute.java
+++ b/src/main/java/de/retest/ui/descriptors/DefaultAttribute.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlElement;
 
 public class DefaultAttribute extends ParameterizedAttribute {
 
-	public static final ParameterType ParameterTypeAttribute = new ParameterType( "ATTRIBUTE" ) {
+	public static final ParameterType parameterTypeAttribute = new ParameterType( "ATTRIBUTE" ) {
 		@Override
 		public Object parse( final String value ) {
 			return null;
@@ -49,7 +49,7 @@ public class DefaultAttribute extends ParameterizedAttribute {
 
 	@Override
 	public ParameterType getType() {
-		return ParameterTypeAttribute;
+		return parameterTypeAttribute;
 	}
 
 	@Override

--- a/src/main/java/de/retest/ui/descriptors/ParameterType.java
+++ b/src/main/java/de/retest/ui/descriptors/ParameterType.java
@@ -55,11 +55,11 @@ public abstract class ParameterType {
 	}
 
 	public static void registerStdParameterTypes() {
-		registerParameterType( PathAttribute.ParameterTypePath );
-		registerParameterType( DefaultAttribute.ParameterTypeAttribute );
-		registerParameterType( StringAttribute.ParameterTypeString );
-		registerParameterType( StringAttribute.ParameterTypeBoolean );
-		registerParameterType( StringAttribute.ParameterTypeInteger );
-		registerParameterType( StringAttribute.ParameterTypeClass );
+		registerParameterType( PathAttribute.parameterTypePath );
+		registerParameterType( DefaultAttribute.parameterTypeAttribute );
+		registerParameterType( StringAttribute.parameterTypeString );
+		registerParameterType( StringAttribute.parameterTypeBoolean );
+		registerParameterType( StringAttribute.parameterTypeInteger );
+		registerParameterType( StringAttribute.parameterTypeClass );
 	}
 }

--- a/src/main/java/de/retest/ui/descriptors/PathAttribute.java
+++ b/src/main/java/de/retest/ui/descriptors/PathAttribute.java
@@ -13,7 +13,7 @@ import de.retest.util.StringSimilarity;
 @XmlRootElement
 public class PathAttribute extends ParameterizedAttribute {
 
-	public static final ParameterType ParameterTypePath = new ParameterType( "PATH" ) {
+	public static final ParameterType parameterTypePath = new ParameterType( "PATH" ) {
 		@Override
 		public Object parse( final String value ) throws ParameterParseException {
 			try {
@@ -84,6 +84,6 @@ public class PathAttribute extends ParameterizedAttribute {
 
 	@Override
 	public ParameterType getType() {
-		return ParameterTypePath;
+		return parameterTypePath;
 	}
 }

--- a/src/main/java/de/retest/ui/descriptors/StringAttribute.java
+++ b/src/main/java/de/retest/ui/descriptors/StringAttribute.java
@@ -12,14 +12,14 @@ import de.retest.util.StringSimilarity;
 @XmlRootElement
 public class StringAttribute extends ParameterizedAttribute {
 
-	public static final ParameterType ParameterTypeString = new ParameterType( "STRING" ) {
+	public static final ParameterType parameterTypeString = new ParameterType( "STRING" ) {
 		@Override
 		public String parse( final String value ) {
 			return value;
 		}
 	};
 
-	public static final ParameterType ParameterTypeClass = new ParameterType( "CLASS_NAME" ) {
+	public static final ParameterType parameterTypeClass = new ParameterType( "CLASS_NAME" ) {
 		@Override
 		public Class<?> parse( final String value ) throws ParameterParseException {
 			try {
@@ -30,7 +30,7 @@ public class StringAttribute extends ParameterizedAttribute {
 		}
 	};
 
-	public static final ParameterType ParameterTypeInteger = new ParameterType( "INTEGER" ) {
+	public static final ParameterType parameterTypeInteger = new ParameterType( "INTEGER" ) {
 		@Override
 		public Integer parse( final String value ) throws ParameterParseException {
 			try {
@@ -41,7 +41,7 @@ public class StringAttribute extends ParameterizedAttribute {
 		}
 	};
 
-	public static final ParameterType ParameterTypeBoolean = new ParameterType( "BOOLEAN" ) {
+	public static final ParameterType parameterTypeBoolean = new ParameterType( "BOOLEAN" ) {
 		@Override
 		public Boolean parse( final String value ) throws ParameterParseException {
 			if ( value.equalsIgnoreCase( "true" ) ) {
@@ -111,6 +111,6 @@ public class StringAttribute extends ParameterizedAttribute {
 
 	@Override
 	public ParameterType getType() {
-		return ParameterTypeString;
+		return parameterTypeString;
 	}
 }

--- a/src/test/java/de/retest/ui/descriptors/DefaultAttributeTest.java
+++ b/src/test/java/de/retest/ui/descriptors/DefaultAttributeTest.java
@@ -1,6 +1,6 @@
 package de.retest.ui.descriptors;
 
-import static de.retest.ui.descriptors.DefaultAttribute.ParameterTypeAttribute;
+import static de.retest.ui.descriptors.DefaultAttribute.parameterTypeAttribute;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -9,7 +9,7 @@ public class DefaultAttributeTest {
 
 	@Test
 	public void parse_is_not_supported_and_should_return_null() throws Exception {
-		assertThat( ParameterTypeAttribute.parse( "value" ) ).isNull();
+		assertThat( parameterTypeAttribute.parse( "value" ) ).isNull();
 	}
 
 }

--- a/src/test/java/de/retest/ui/descriptors/PathAttributeTest.java
+++ b/src/test/java/de/retest/ui/descriptors/PathAttributeTest.java
@@ -1,6 +1,6 @@
 package de.retest.ui.descriptors;
 
-import static de.retest.ui.descriptors.PathAttribute.ParameterTypePath;
+import static de.retest.ui.descriptors.PathAttribute.parameterTypePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
@@ -16,7 +16,7 @@ public class PathAttributeTest {
 		final Path path = Path.path( parent, new PathElement( "path" ) );
 		final Path test = Path.path( path, new PathElement( "test" ) );
 
-		assertThat( ParameterTypePath.parse( "parent/path/test" ) ).isEqualTo( test );
+		assertThat( parameterTypePath.parse( "parent/path/test" ) ).isEqualTo( test );
 	}
 
 }

--- a/src/test/java/de/retest/ui/descriptors/StringAttributeTest.java
+++ b/src/test/java/de/retest/ui/descriptors/StringAttributeTest.java
@@ -1,9 +1,9 @@
 package de.retest.ui.descriptors;
 
-import static de.retest.ui.descriptors.StringAttribute.ParameterTypeBoolean;
-import static de.retest.ui.descriptors.StringAttribute.ParameterTypeClass;
-import static de.retest.ui.descriptors.StringAttribute.ParameterTypeInteger;
-import static de.retest.ui.descriptors.StringAttribute.ParameterTypeString;
+import static de.retest.ui.descriptors.StringAttribute.parameterTypeBoolean;
+import static de.retest.ui.descriptors.StringAttribute.parameterTypeClass;
+import static de.retest.ui.descriptors.StringAttribute.parameterTypeInteger;
+import static de.retest.ui.descriptors.StringAttribute.parameterTypeString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
@@ -17,14 +17,14 @@ public class StringAttributeTest {
 
 	@Test
 	public void should_parse_Boolean_values_correctly() throws Exception {
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "TRUE" ) ).isTrue();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "True" ) ).isTrue();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "true" ) ).isTrue();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "TrUe" ) ).isTrue();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "FALSE" ) ).isFalse();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "False" ) ).isFalse();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "false" ) ).isFalse();
-		assertThat( (Boolean) ParameterTypeBoolean.parse( "fAlSe" ) ).isFalse();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "TRUE" ) ).isTrue();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "True" ) ).isTrue();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "true" ) ).isTrue();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "TrUe" ) ).isTrue();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "FALSE" ) ).isFalse();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "False" ) ).isFalse();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "false" ) ).isFalse();
+		assertThat( (Boolean) parameterTypeBoolean.parse( "fAlSe" ) ).isFalse();
 	}
 
 	@Test
@@ -32,37 +32,37 @@ public class StringAttributeTest {
 		exception.expect( ParameterParseException.class );
 		exception.expectMessage( "Value must be 'true' or 'false' (ignoring case)." );
 
-		ParameterTypeBoolean.parse( "not a boolean value" );
+		parameterTypeBoolean.parse( "not a boolean value" );
 	}
 
 	@Test
 	public void should_parse_Class_values_correctly() throws Exception {
-		assertThat( ParameterTypeClass.parse( "java.lang.Integer" ) ).isEqualTo( Integer.class );
-		assertThat( ParameterTypeClass.parse( "de.retest.ui.descriptors.StringAttributeTest" ) )
+		assertThat( parameterTypeClass.parse( "java.lang.Integer" ) ).isEqualTo( Integer.class );
+		assertThat( parameterTypeClass.parse( "de.retest.ui.descriptors.StringAttributeTest" ) )
 				.isEqualTo( getClass() );
 	}
 
 	@Test( expected = ParameterParseException.class )
 	public void parse_should_throw_class_not_found() throws Exception {
-		assertThat( ParameterTypeClass.parse( "this.is.a.non.existent.Class" ) );
+		assertThat( parameterTypeClass.parse( "this.is.a.non.existent.Class" ) );
 	}
 
 	@Test
 	public void should_return_String_values_as_is() throws Exception {
-		assertThat( ParameterTypeString.parse( "Hi" ) ).isEqualTo( "Hi" );
-		assertThat( ParameterTypeString.parse( "42" ) ).isEqualTo( "42" );
-		assertThat( ParameterTypeString.parse( "true" ) ).isEqualTo( "true" );
+		assertThat( parameterTypeString.parse( "Hi" ) ).isEqualTo( "Hi" );
+		assertThat( parameterTypeString.parse( "42" ) ).isEqualTo( "42" );
+		assertThat( parameterTypeString.parse( "true" ) ).isEqualTo( "true" );
 	}
 
 	@Test
 	public void should_parse_Integer_correctly() throws Exception {
-		assertThat( ParameterTypeInteger.parse( "42" ) ).isEqualTo( 42 );
-		assertThat( ParameterTypeInteger.parse( "4711" ) ).isEqualTo( 4711 );
-		assertThat( ParameterTypeInteger.parse( "0815" ) ).isEqualTo( 815 );
+		assertThat( parameterTypeInteger.parse( "42" ) ).isEqualTo( 42 );
+		assertThat( parameterTypeInteger.parse( "4711" ) ).isEqualTo( 4711 );
+		assertThat( parameterTypeInteger.parse( "0815" ) ).isEqualTo( 815 );
 	}
 
 	@Test( expected = ParameterParseException.class )
 	public void parse_should_throw_exception() throws Exception {
-		ParameterTypeInteger.parse( "test" );
+		parameterTypeInteger.parse( "test" );
 	}
 }


### PR DESCRIPTION
Static final fields that are followed with a dot should use lower camel case (just like logger).