### PR TITLE
Validate constructor args for element

### DIFF
--- a/src/main/java/de/retest/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/ui/descriptors/Element.java
@@ -63,8 +63,7 @@ public class Element implements Serializable, Comparable<Element> {
 
 	public Element( final String retestId, final IdentifyingAttributes identifyingAttributes,
 			final Attributes attributes, final Element... containedComponents ) {
-		this( retestId, identifyingAttributes, attributes,
-				new ArrayList<>( Arrays.asList( containedComponents ) ) );
+		this( retestId, identifyingAttributes, attributes, new ArrayList<>( Arrays.asList( containedComponents ) ) );
 	}
 
 	public Element( final String retestId, final IdentifyingAttributes identifyingAttributes,
@@ -81,7 +80,13 @@ public class Element implements Serializable, Comparable<Element> {
 			final Attributes attributes, final List<Element> containedComponents, final Screenshot screenshot ) {
 		this.retestId = verify( retestId, identifyingAttributes );
 		this.identifyingAttributes = identifyingAttributes;
+		if ( identifyingAttributes == null ) {
+			throw new NullPointerException( "IdentifyingAttributes must not be null." );
+		}
 		this.attributes = attributes;
+		if ( attributes == null ) {
+			throw new NullPointerException( "Attributes must not be null." );
+		}
 		this.containedComponents = containedComponents;
 		this.screenshot = screenshot;
 	}

--- a/src/test/java/de/retest/ui/descriptors/ElementTest.java
+++ b/src/test/java/de/retest/ui/descriptors/ElementTest.java
@@ -19,7 +19,7 @@ public class ElementTest {
 	public void toString_returns_UniqueCompIdentAttributes_toString() throws Exception {
 		final IdentifyingAttributes compIdentAttributes = IdentifyingAttributes
 				.create( fromString( "Window[1]/Path[1]/Component[1]" ), java.awt.Component.class );
-		assertThat( new Element( "asdef", compIdentAttributes, null ).toString() )
+		assertThat( new Element( "asdef", compIdentAttributes, new Attributes() ).toString() )
 				.isEqualTo( compIdentAttributes.toString() );
 		assertThat( compIdentAttributes.toString() ).isEqualTo( "Component" );
 	}


### PR DESCRIPTION
To prevent something like
java.lang.NullPointerException: null
	at de.retest.ui.descriptors.Element.hashCode(SourceFile:132)
	at java.util.HashMap.hash(HashMap.java:338)
	at java.util.HashMap.get(HashMap.java:556)