### PR TITLE
SimpleDateFormat should not be persisted with `GroundState`

### DIFF
--- a/src/main/java/de/retest/ui/descriptors/GroundState.java
+++ b/src/main/java/de/retest/ui/descriptors/GroundState.java
@@ -35,7 +35,7 @@ public class GroundState implements Serializable {
 	public static final String UNSPECIFIED = "unspecified SUT version";
 
 	// SimpleDateFormat is not thread-safe, so don't make it static
-	private final SimpleDateFormat xmlDateFormat = new SimpleDateFormat( "dd.MM.yyyy-HH:mm:ss:SSS" );
+	private final transient SimpleDateFormat xmlDateFormat = new SimpleDateFormat( "dd.MM.yyyy-HH:mm:ss:SSS" );
 
 	@XmlElement
 	protected final String sutVersion;


### PR DESCRIPTION
Exception Description: The object [java.text.SimpleDateFormat@10d08d46], of class [class java.lang.String], from mapping [org.eclipse.persistence.oxm.mappings.XMLDirectMapping[xmlDateFormat-->xmlDateFormat/text()]] with descriptor [XMLDescriptor(de.retest.ui.descriptors.GroundState --> [DatabaseTable(groundState)])], could not be converted to [class java.text.SimpleDateFormat].]