### PR TITLE
In case of exception log more...

### DIFF
--- a/src/main/java/de/retest/ui/image/ImageUtils.java
+++ b/src/main/java/de/retest/ui/image/ImageUtils.java
@@ -238,7 +238,8 @@ public class ImageUtils {
 		try {
 			return image.getSubimage( bounds.x, bounds.y, bounds.width, bounds.height );
 		} catch ( final Exception exc ) {
-			logger.error( "Exception cutting image: ", exc );
+			logger.error( "Exception cutting image with width/height {}/{} to bounds {}: ", image.getWidth(),
+					image.getHeight(), bounds, exc );
 		}
 		return image;
 	}


### PR DESCRIPTION
[AWT-EventQueue-0] ERROR de.retest.ui.image.ImageUtils - Exception cutting image:
java.awt.image.RasterFormatException: negative or zero height
	at java.awt.image.Raster.<init>(Raster.java:1105)
	at java.awt.image.WritableRaster.<init>(WritableRaster.java:129)
	at sun.awt.image.SunWritableRaster.<init>(SunWritableRaster.java:129)
	at sun.awt.image.ByteComponentRaster.<init>(ByteComponentRaster.java:154)
	at sun.awt.image.ByteInterleavedRaster.<init>(ByteInterleavedRaster.java:191)
	at sun.awt.image.ByteInterleavedRaster.createWritableChild(ByteInterleavedRaster.java:1261)
	at java.awt.image.BufferedImage.getSubimage(BufferedImage.java:1202)
	at de.retest.ui.image.ImageUtils.cutImage(ImageUtils.java:235)
	at de.retest.ui.image.ImageUtils.cutImage(ImageUtils.java:205)
	at de.retest.gui.review.ElementDifferenceTreeNode.getActualScreenshot(ElementDifferenceTreeNode.java:131)
	at de.retest.gui.review.ElementDifferenceDetailsModel.updateDetailsView(ElementDifferenceDetailsModel.java:74)
	at de.retest.gui.review.ElementDifferenceTreeNode.getDetailsViewComponent(ElementDifferenceTreeNode.java:54)