### PR TITLE
Working fine with EclipseLink 2.5.2, but moving to 2.6.0 breaks the X…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,11 +103,10 @@
 			<version>1.7.25</version>
 		</dependency>
 
-		<!-- version 2.6+ isn't Java 6 compatible -->
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>org.eclipse.persistence.moxy</artifactId>
-			<version>2.7.3</version>
+				<version>2.5.2</version><!-- moving to 2.6.0 breaks the XmlValue annotation -->
 		</dependency>
 
 		<!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>org.eclipse.persistence.moxy</artifactId>
-				<version>2.5.2</version><!-- moving to 2.6.0 breaks the XmlValue annotation -->
+			<version>2.5.2</version><!-- moving to 2.6.0 breaks the XmlValue annotation -->
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
…mlValue annotation

See https://stackoverflow.com/questions/32625797/make-use-of-xmlvalue-in-subclass

Caused by: Exception [EclipseLink-50011] (Eclipse Persistence Services - 2.7.3.v20180807-4be1041): org.eclipse.persistence.exceptions.JAXBException
Exception Description: The property or field path cannot be annotated with XmlValue since it is a subclass of another XML-bound class.
    at org.eclipse.persistence.exceptions.JAXBException.propertyOrFieldCannotBeXmlValue(JAXBException.java:270)
    at org.eclipse.persistence.jaxb.compiler.AnnotationsProcessor.validateXmlValueFieldOrProperty(AnnotationsProcessor.java:4106)
    at org.eclipse.persistence.jaxb.compiler.AnnotationsProcessor.finalizeProperties(AnnotationsProcessor.java:978)
    at org.eclipse.persistence.jaxb.compiler.AnnotationsProcessor.processClassesAndProperties(AnnotationsProcessor.java:307)
    at org.eclipse.persistence.jaxb.compiler.Generator.<init>(Generator.java:163)
    at org.eclipse.persistence.jaxb.JAXBContext$TypeMappingInfoInput.createContextState(JAXBContext.java:1159)